### PR TITLE
解决4字节长度的数据无法解析

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -34,6 +34,10 @@ const StackBuffer = function (bufferLength) {
         _writeIntMethod = 'writeInt' + type + 'BE';
         _dataHeadLen = (type === 16) ? 2 : 4;
 
+        this.readIntMethod = _readIntMethod
+        this.writeIntMethod = _writeIntMethod
+        this.dataHeadLen = _dataHeadLen
+
         return this;
     }
 
@@ -50,6 +54,11 @@ const StackBuffer = function (bufferLength) {
         _readIntMethod = 'readInt' + type + 'LE';
         _writeIntMethod = 'writeInt' + type + 'LE';
         _dataHeadLen = (type === 16) ? 2 : 4;
+
+        this.readIntMethod = _readIntMethod
+        this.writeIntMethod = _writeIntMethod
+        this.dataHeadLen = _dataHeadLen
+
         return this;
     }
 


### PR DESCRIPTION
type=32的option设置，测试结果不能解析